### PR TITLE
Adds a missing variable to sampledotenv

### DIFF
--- a/sampledotenv
+++ b/sampledotenv
@@ -1,4 +1,5 @@
 # Save this file as .env and fill in the appropriate values
+DM_API_ROOT=/api
 DM_BASE_URL=http://localhost:3000/
 DM_COMMENTS_DB_URL=mongodb://localhost:27017
 DM_COMMENTS_DB_NAME=dm_comments_api


### PR DESCRIPTION
Adds the missing `DM_API_ROOT=/api` variable to sampledotenv.